### PR TITLE
adding BeforeFlagParseHook() hook 

### DIFF
--- a/.github/workflows/gochecks.yml
+++ b/.github/workflows/gochecks.yml
@@ -1,0 +1,22 @@
+name: go-checks
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setup Go environment
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          check-latest: true
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# Config for golanglint-ci
+# Config for golangci-lint
 
 # output configuration options
 
@@ -45,14 +45,6 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).FErrf
     enable-all: true
     disable-all: false
-  depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - github.com/sirupsen/logrus
-    packages-with-error-message:
-      # specify an error message to output when a blacklisted package is used
-      - github.com/sirupsen/logrus: "logging is allowed only by fortio.log"
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option
@@ -115,6 +107,7 @@ linters:
     - cyclop
     - forcetypeassert
     - ireturn
+    - depguard
   enable-all: true
   disable-all: false
   # Must not use fast: true in newer golangci-lint or it'll just skip a bunch of linter instead of doing caching like before (!)

--- a/cli.go
+++ b/cli.go
@@ -49,7 +49,7 @@ var (
 	ExitFunction = os.Exit
 	// Hook to call before flag.Parse() - for instance to use ChangeFlagDefaults for logger flags etc.
 	BeforeFlagParseHook = func() {}
-	// Calculated base exe name from args (will be used if ProgramName if not set)
+	// Calculated base exe name from args (will be used if ProgramName if not set).
 	baseExe string
 )
 


### PR DESCRIPTION
So programs can call ChangeFlagsDefault() to change some of the default for flags created by cli/scli