### PR TITLE
Fix Apache license copyright placeholder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023 Laurent Demailly and fortio contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The Apache License template still contains the unfilled copyright
placeholder:

```
   Copyright [yyyy] [name of copyright owner]
```

This PR replaces it with the correct copyright information.
